### PR TITLE
[fix] Cannot read files with paths encoded as URI Components

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -10,7 +10,7 @@ core
     })
     .get("/*", async ctx => {
         const summary = await getSummary();
-        const content = await getDocument(ctx.path);
+        const content = await getDocument(decodeURIComponent(ctx.path));
         return ctx.render(tmpl, { meta, summary, content });
     })
     .listen();


### PR DESCRIPTION
Some characters are encoded as URIComponent when retrieving path and stored in the variable.
For this reason, using path as-is for the path of a file to be referenced sometimes resulted in a "file does not exist" error, which has been corrected.
This PR fixes this problem.

## Steps to reproduce
if you create "あいうえお.md" (Japanese, which is one of the character types encoded in path) and access `http://localhost:3000/あいうえお.md` to open it, you will get an error like this:
```
[Core] NotFound: Cannot find or open document "%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.md".
    at async Object.readTextFile (deno:runtime/js/40_read_file.js:56:20)
    at async getDocument (https://deno.land/x/book@0.0.2/docs.ts:18:26)
    at async Object.callback (https://deno.land/x/book@0.0.2/mod.ts:13:25)
    at async Server.#handleRequest (https://deno.land/x/core@0.0.2/server.ts:109:24)
    at async Server.#respond (https://deno.land/std@0.177.0/http/server.ts:299:18)
```

## Solution
It can be undone with `decodeURIComponent`.
```
> decodeURIComponent('%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A.md')
"あいうえお.md".
```

(I'm Japanese and my English isn't great, so sorry if I made any mistakes!)